### PR TITLE
Update to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyQt5>=5.15.7
 requests>=2.28.0
 torch>=1.12.1
 opencv_python>=4.2.0.32
+transformers>=4.22.1


### PR DESCRIPTION
To solve possible error from missing dependency.  Dependencies installed via `pip install -r requirements.txt` in an Anaconda environment yielded the following error.

```
ImportError:
StableDiffusionPipeline requires the transformers library but it was not found in your environment. You can install it with pip: `pip
install transformers`
```