### PR TITLE
Easier Windows Local GPU setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ https://user-images.githubusercontent.com/6392321/191858568-0550f52d-e89c-4b37-a
 1. Install the dependencies (for example using `pip`). The dependencies include :
 * `PyQt5`, `numpy`, `pytorch`, `Pillow`, `opencv-python`, `requests`, `flask`, `diffusers`, `transformers`, `protobuf`
 
-Note that if you want to run StableDiffusion locally, you have to install pytorch with cuda enabled like this:
+Note that if you want to run StableDiffusion on Windows locally, use requirements-localgpu-win64.txt
 ```
-pip install torch==1.12.1+cu113 -f https://download.pytorch.org/whl/torch_stable.html
+pip -r requirements-localgpu-win64.txt
 ```
 
 Note: On linux, if you encounter `Could not load the Qt platform plugin "xcb"` error, run this:

--- a/requirements-localgpu-win64.txt
+++ b/requirements-localgpu-win64.txt
@@ -1,0 +1,12 @@
+#pip install -r requirements_localgpu-win64.txt
+diffusers>=0.3.0
+Flask>=1.1.2
+numpy>=1.21.6
+Pillow>=9.2.0
+protobuf>=4.21.6
+PyQt5>=5.15.7
+requests>=2.28.0
+opencv_python>=4.2.0.32
+transformers>=4.22.1
+--extra-index-url https://download.pytorch.org/whl/cu113 --trusted-host https://download.pytorch.org
+torch>=1.12.1


### PR DESCRIPTION
Added requirements.txt variant for Windows users who wish to run local GPU, to simplify install to two steps w/ Python preinstalled;

1) pip install -r requirements-localgpu-win64.txt
2) python unstablediffusion.py

- Uses public precompiled pytorch for cuda support