### PR TITLE
Improve performance 2-3x times by enabling attention slicing.

### DIFF
--- a/diffusionserver.py
+++ b/diffusionserver.py
@@ -55,6 +55,10 @@ class StableDiffusionHandler:
         self.inpainter.safety_checker = dummy_safety_checker
         self.img2img.safety_checker = dummy_safety_checker
         self.text2img.safety_checker = dummy_safety_checker
+        
+        self.text2img.enable_attention_slicing()
+        self.img2img.enable_attention_slicing()
+        self.inpainter.enable_attention_slicing()
     
     def get_generator(self, seed):
         if seed == -1:


### PR DESCRIPTION
When enabling attention slicing on diffusers we can get up to 3 times the performance we have when not using it, [here ](https://huggingface.co/docs/diffusers/optimization/fp16#sliced-attention-for-additional-memory-savings)are the docs for attention slicing.