### PR TITLE
Fix typo in requirements-localgpu-win64.txt

### DIFF
--- a/requirements-localgpu-win64.txt
+++ b/requirements-localgpu-win64.txt
@@ -1,5 +1,5 @@
 #pip install -r requirements-localgpu-win64.txt
-diffusers=0.6.0
+diffusers==0.6.0
 Flask>=1.1.2
 numpy>=1.21.6
 Pillow>=9.2.0


### PR DESCRIPTION
Syntax issue on yesterday's commit:

```
PS C:\> pip install -r requirements-localgpu-win64.txt
ERROR: Invalid requirement: 'diffusers=0.6.0' (from line 2 of requirements-localgpu-win64.txt)
Hint: = is not a valid operator. Did you mean == ?
```